### PR TITLE
Encabezados y errores de dedo

### DIFF
--- a/reports/metricas_anual_y_por_partido.html
+++ b/reports/metricas_anual_y_por_partido.html
@@ -19,7 +19,7 @@
             <p class="lead" style="font-size:1.7em">
             En la figura 1 podemos observar la posesión en algunos partidos de los Cimarrones. Las barras
             horizontales azules representa la posesión de los Cimarrones y las barras rojas a sus
-            rivales. Tomamos solo seis partidos para hacer un muestra de esta métrica.
+            rivales. Tomamos solo seis partidos para hacer una muestra de esta métrica.
             </p>
             <p class="lead" style="font-size:1.7em">
             La primer barra representa el partido de Cimarrones vs Cancún (con marcador

--- a/reports/metricas_anual_y_por_partido.html
+++ b/reports/metricas_anual_y_por_partido.html
@@ -22,7 +22,7 @@
             rivales. Tomamos solo seis partidos para hacer un muestra de esta métrica.
             </p>
             <p class="lead" style="font-size:1.7em">
-            La primer barra de representa el partido de Cimarrones vs Cancún (con marcador
+            La primer barra representa el partido de Cimarrones vs Cancún (con marcador
             0 a 1). Al pasar el cursor podemos ver el sistema de juegos de cada equipo: Cimarrones
             jugaron con 4-3-1-2 y Cancún un sistema 4-5-1. La última barra corresponde al partido
             contra Tepatitlán, podemos notar que Cimarrones ganó 2 a 0 con un posesión menor al 40%.
@@ -42,7 +42,7 @@
 		<div class="container-lg">
       <h2>Métricas en el torneo presente</h2>
             <p class="lead" style="font-size:1.7em">
-            La figura 2 muestra algunas métricas para los partidos jugados por los Cimarrones este
+            La figura 2 muestra algunas métricas para los partidos jugados por los Cimarrones en este
             torneo. La barra central de color verde reperesenta el promedio anual para cada una
             de las variables. En el 67% de los partidos jugados, las metricas cayeron en ese
             intervalo. Las líneas punteadas de color naranja representan el 95% de los eventos y
@@ -52,10 +52,10 @@
             Los valores de las métricas en la figura 2 están normalizados con fines de visualización.
             Al pasar el cursor por cada una de las barras azules podemos ver los valores crudos y el
             promedio anual. En la parte superior podemos ver una pestaña para cada uno de los partidos
-            jugados este torneo.
+            jugados en este torneo.
             </p>
             <p class="lead" style="font-size:1.7em">
-            En su primer partido, Cimarrones solo alcanzó un xG de 0.33, menos al ~1.5
+            En su primer partido, Cimarrones solo alcanzó un xG de 0.33, menor al ~1.5
             correspondiente al promedio del año pasado. Las pérdidas bajas fueron de 9 (y el
             promedio del año fue de 16).
             </p>

--- a/reports/metricas_anual_y_por_partido.html
+++ b/reports/metricas_anual_y_por_partido.html
@@ -14,7 +14,7 @@
     </head>
     <body>
 		<div class="container-lg">
-      <h1>Métricas de los cimarrones</h1>
+      <h1>Cimarrones de Sonora F.C.</h1>
       <h2>Métricas de referencia</h2>
             <p class="lead" style="font-size:1.7em">
             En la figura 1 podemos observar la posesión en algunos partidos de los Cimarrones.

--- a/reports/metricas_anual_y_por_partido.html
+++ b/reports/metricas_anual_y_por_partido.html
@@ -17,10 +17,9 @@
       <h1>Cimarrones de Sonora F.C.</h1>
       <h2>Métricas de referencia</h2>
             <p class="lead" style="font-size:1.7em">
-            En la figura 1 podemos observar la posesión en algunos partidos de los Cimarrones.
-            Tomamos solo seis partidos para hacer un muestra de esta métrica. Las barras
+            En la figura 1 podemos observar la posesión en algunos partidos de los Cimarrones. Las barras
             horizontales azules representa la posesión de los Cimarrones y las barras rojas a sus
-            rivales.
+            rivales. Tomamos solo seis partidos para hacer un muestra de esta métrica.
             </p>
             <p class="lead" style="font-size:1.7em">
             La primer barra de representa el partido de Cimarrones vs Cancún (con marcador


### PR DESCRIPTION
Te paso una revisión buscando errores de dedo. Cambié el primer encabezado porque la palabra métrica parece repetitiva con los otros dos. Quito unas palabras y agrego otras para darle (según yo) un poco más de entendimiento.